### PR TITLE
Add support for T4950-IAQ with sensor child devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,12 @@ Once you have completed these steps, confirm that your thermostat's API is reach
 
 You can then create a device for the thermostat using the driver.
 
+If you would like to make use of built-in or connected sensors, you will need to import a second driver from this URL:
+
+    https://raw.githubusercontent.com/toggledbits/VenstarColorTouch-Hubitat/main/drivers/VenstarSensor.groovy
+
+Once both drivers have been imported and you have created a thermostat device, click the "Create Sensor Child Devices" command button on your newly created thermostat device. This will automatically create child devices for all sensors that are present.
+
 ## Device Configuration
 
 Configuration should be pretty straight-forward. You need to supply the IP address of the thermostat and select the API protocol (HTTP or HTTPS), at a minimum, and of course, these need to match the configuration of the thermostat itself.

--- a/drivers/VenstarSensor.groovy
+++ b/drivers/VenstarSensor.groovy
@@ -1,0 +1,40 @@
+metadata {
+  definition(name: "Venstar Thermostat Sensor", namespace: "toggledbits.com", author: "Sasha Kotlyar") {
+    capability "TemperatureMeasurement"
+    capability "RelativeHumidityMeasurement"
+    capability "AirQuality"
+    capability "CarbonDioxideMeasurement"
+    capability "IlluminanceMeasurement"
+  }
+}
+
+def processSensorData(dataMap, providedTempUnits)
+{
+  if (dataMap["temp"] != null) {
+    temp = dataMap["temp"]
+    if (location.temperatureScale == "F" && providedTempUnits == 1) temp = celsiusToFahrenheit(temp)
+    else if (location.temperatureScale == "C" && providedTempUnits == 0) temp = fahrenheitToCelsius(temp)
+    temp = (temp as double).round(2)
+    sendEvent(name: "temperature", value: temp, unit: "°${location.temperatureScale}", descriptionText: "Temperature is ${temp}°${location.temperatureScale}")
+  }
+
+  if (dataMap["hum"] != null) {
+    humidity = dataMap["hum"]
+    sendEvent(name: "humidity", value: humidity, descriptionText: "Relative humidity is ${humidity}%")
+  }
+
+  if (dataMap["iaq"] != null) {
+    sendEvent(name: "airQualityIndex", value: dataMap["iaq"], descriptionText: "Indoor Air Quality (IAQ) is ${dataMap["iaq"]}")
+  }
+
+  if (dataMap["co2"] != null) {
+    sendEvent(name: "carbonDioxide", value: dataMap["co2"], descriptionText: "Carbon dioxide level is ${dataMap["co2"]} ppm")
+  }
+
+  if (dataMap["intensity"] != null) {
+    sendEvent(name: "illuminance", value: dataMap["intensity"], descriptionText: "Light intensity is ${dataMap["intensity"]}")
+  } else {
+    /* "intensity" is not included in the JSON payload when its value is 0, so remove the state data for equivalent functionality. */
+    device.deleteCurrentState("illuminance")
+  }
+}


### PR DESCRIPTION
Hello again!

I ended up getting a T4950-IAQ, which includes useful measurements like IAQ and CO₂ (likely eCO₂, but still). To access those measurements, the `/query/sensors` endpoint must be used. Since you had mentioned wanting to use child devices in the TODOs in your code, that's the direction I took.

In order to avoid unnecessary load on the thermostat and HE, this endpoint will only be queried after the user has clicked the new "Create Sensor Child Devices" button and at least one child device exists.

Here's sample output from the T4950-IAQ's sensors endpoint:

```json
{
  "sensors": [
    {
      "name": "Thermostat",
      "temp": 71,
      "hum": 40,
      "iaq": 45.53,
      "co2": 582.12
    },
    {
      "name": "Space Temp",
      "temp": 71
    }
  ]
}
```

I took the opportunity to bring this driver more in line with first party ones by adding an "Enable descriptionText logging" option, which allows the user to disable recurring info-level logs.

As for the new `VenstarSensor.groovy` file used for the child devices, I wasn't sure how you wanted to structure any header comments, so I didn't add them. Please feel free to edit authorship-related stuff as you see fit. (The MIT license is a great choice, by the way, so I have no issues sticking with it.)

Thanks!